### PR TITLE
Add alternative album cover selection and improve report feedback

### DIFF
--- a/app/controllers/report_reviews_controller.rb
+++ b/app/controllers/report_reviews_controller.rb
@@ -4,12 +4,13 @@ class ReportReviewsController < ApplicationController
 
   def fetch_report
     @snippet_report = SnippetReport
+      # TODO: add filtering out of reports from current user
       .where(status: "pending")
       .where.not(
         id: ReportVote.select(:snippet_report_id).where(user_id: current_user.id)
       )
       .sample
-      
+
     if @snippet_report
       render json: report_data(@snippet_report)
     else

--- a/app/controllers/snippet_reports_controller.rb
+++ b/app/controllers/snippet_reports_controller.rb
@@ -14,11 +14,19 @@ class SnippetReportsController < ApplicationController
         user_name: current_user.name
       }
     else
-      render json: {
-        status: "error",
-        message: "Failed to submit report",
-        errors: @snippet_report.errors.full_messages
-      }, status: :unprocessable_entity
+      if @snippet_report.errors.details[:user]&.any? { |e| e[:error] == :taken }
+        render json: {
+          status: "error",
+          message: "You have already reported this snippet",
+          errors: @snippet_report.errors.full_messages
+        }, status: :unprocessable_entity
+      else
+        render json: {
+          status: "error",
+          message: "Failed to submit report - snippet_reports_controller#create",
+          errors: @snippet_report.errors.full_messages
+        }, status: :unprocessable_entity
+      end
     end
   end
 

--- a/app/controllers/snippets_controller.rb
+++ b/app/controllers/snippets_controller.rb
@@ -43,6 +43,12 @@ class SnippetsController < ApplicationController
     }
   end
 
+  def fetch_alternative_album_covers
+    artist_name = params[:artist_name]
+    alternative_album_covers = LyricSnippet.find_alternative_album_covers(artist_name)
+    render json: alternative_album_covers
+  end
+
   def languages
     render json: LyricSnippet.languages
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,6 +11,10 @@ class UsersController < ApplicationController
   def update
   end
 
+  def current_user_id
+    render json: { id: current_user.id }
+  end
+
   def search
     Rails.logger.debug "Search action called"
     Rails.logger.debug "Search params: #{params.inspect}"

--- a/app/javascript/components/ImageSelector.js
+++ b/app/javascript/components/ImageSelector.js
@@ -1,0 +1,69 @@
+// Create new file: app/javascript/components/ImageSelector.js
+import React, { useState, useEffect } from 'react';
+
+function ImageSelector({ artist, song, currentImageUrl, onImageSelect }) {
+  const [imageOptions, setImageOptions] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [selectedImage, setSelectedImage] = useState(null);
+
+  useEffect(() => {
+    if (artist && song) {
+      fetchImageOptions();
+    }
+  }, [artist, song]);
+
+  const fetchImageOptions = async () => {
+    setLoading(true);
+    try {
+      const response = await fetch(`/snippets/image_options?artist=${encodeURIComponent(artist)}&song=${encodeURIComponent(song)}`);
+      const data = await response.json();
+      setImageOptions(data.images || []);
+    } catch (error) {
+      console.error('Error fetching image options:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleImageSelect = (imageUrl) => {
+    setSelectedImage(imageUrl);
+    onImageSelect(imageUrl);
+  };
+
+  if (loading) {
+    return <div className="text-center">Loading alternative images...</div>;
+  }
+
+  return (
+    <div className="image-selector">
+      <div className="row g-2">
+        {imageOptions.map((imageUrl, index) => (
+          <div key={index} className="col-6 col-md-4">
+            <div 
+              className={`image-option ${selectedImage === imageUrl ? 'selected' : ''}`}
+              onClick={() => handleImageSelect(imageUrl)}
+              style={{
+                border: selectedImage === imageUrl ? '3px solid #553d67' : '1px solid #ddd',
+                borderRadius: '8px',
+                overflow: 'hidden',
+                cursor: 'pointer',
+                aspectRatio: '1/1'
+              }}
+            >
+              <img 
+                src={imageUrl} 
+                alt={`Album cover option ${index + 1}`}
+                style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+      {imageOptions.length === 0 && (
+        <p className="text-muted small">No alternative images found</p>
+      )}
+    </div>
+  );
+}
+
+export default ImageSelector;

--- a/app/javascript/components/ReportModal.js
+++ b/app/javascript/components/ReportModal.js
@@ -1,33 +1,33 @@
 import React, { useState, useEffect } from 'react';
 import DifficultySlider from './DifficultySlider';
+import ImageSelector from './ImageSelector';
 
 function ReportModal({ snippet, onSubmit, onClose }) {
   const [loading, setLoading] = useState(true);
+  const [showSuccessfulReportView, setShowSuccessfulReportView] = useState(false);
   const [wrongFields, setWrongFields] = useState({});
   const [suggestions, setSuggestions] = useState({});  
-  // todo make language use snippet.language
   const [languages, setLanguages] = useState([]);
   const [isBoring, setIsBoring] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
-  const [showSuccessfulReportView, setShowSuccessfulReportView] = useState(false);
   const [userName, setUserName] = useState('');
-
+  
   useEffect(() => {
     fetch('/languages')
-      .then(response => response.json())
-      .then(data => {
-        setLanguages(data);
-        setLoading(false);
-      })
-      .catch((error) => {
-        console.error('Error fetching languages:', error);
-        setLoading(false);
-      });
+    .then(response => response.json())
+    .then(data => {
+      setLanguages(data);
+      setLoading(false);
+    })
+    .catch((error) => {
+      console.error('Error fetching languages:', error);
+      setLoading(false);
+    });
   }, []);
-
+  
   const buildFieldClasses = (fieldName) => {
     let classes = 'report-field';
-
+    
     if (wrongFields[fieldName]) {
       classes += ' report-field--selected';
     }
@@ -38,14 +38,16 @@ function ReportModal({ snippet, onSubmit, onClose }) {
     
     return classes;
   };
-
+  
   const calculateWordSimilarity = (original, suggestion) => {
     const originalWords = original.toLowerCase().split(/\s+/);
     const suggestedWords = suggestion.toLowerCase().split(/\s+/); 
     const matches = originalWords.filter(word => suggestedWords.includes(word));
-
+    
     return matches.length / originalWords.length;
   };
+  
+  const selectableLanguages = languages.filter(lang => lang !== snippet?.language);
 
   const validateSubmission = () => {
     if (isBoring) {
@@ -134,11 +136,11 @@ function ReportModal({ snippet, onSubmit, onClose }) {
           }, 2500);
         } else {
           const error = await response.json();
-          setErrorMessage(error.message || 'Failed to submit report');
+          setErrorMessage(error.message || 'Failed to submit report (handleSubmit - else');
         }
       } catch (error) {
         console.error('Error submitting report:', error);
-        setErrorMessage('Failed to submit report');
+        setErrorMessage('Failed to submit report (handleSubmit - catch');
       }
     } else {
       setErrorMessage(validation.message);
@@ -160,8 +162,6 @@ function ReportModal({ snippet, onSubmit, onClose }) {
       </div>
     );
   };
-
-  const selectableLanguages = languages.filter(lang => lang !== snippet?.language);
 
   const renderFormContent = () => {
     return (
@@ -268,6 +268,29 @@ function ReportModal({ snippet, onSubmit, onClose }) {
             />
             Too boring! - Delete!
           </label>
+        </div>
+
+        <div className={`form-section ${isBoring ? 'form-section--disabled' : ''}`}>
+          <label>
+            <input 
+              type="checkbox" 
+              className="form-check-input"
+              checked={wrongFields.image || false} 
+              onChange={() => !isBoring && toggleField('image')} 
+            />
+            Wrong image
+          </label>
+          {wrongFields.image && (
+            <div className="suggestion-section">
+              <p className="small text-muted mb-2">Select the correct album cover:</p>
+              <ImageSelector 
+                artist={snippet?.artist}
+                song={snippet?.song}
+                currentImageUrl={snippet?.image_url}
+                onImageSelect={(imageUrl) => setSuggestions({...suggestions, image: imageUrl})}
+              />
+            </div>
+          )}
         </div>
 
         <div className='modal-button-group'> 


### PR DESCRIPTION
- Add API and model logic to fetch up to 4 alternative album covers from Spotify
- Add image selector to ReportModal for choosing alternative covers
- Improve error feedback for duplicate snippet reports
- Add current_user_id endpoint for frontend use
- Refactor and clarify Spotify API methods in LyricSnippet